### PR TITLE
Include jspm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,17 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/devongovett/browserify-zlib.git"
+  },
+  "jspm": {
+    "dependencies": {
+      "readable-stream": "^1.0.27-1",
+      "pako": "~0.2.0"
+    },
+    "map": {
+      "_stream_transform": "readable-stream/transform",
+      "./src/index.js": {
+        "node": "@node/zlib"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR includes the necessary jspm configuration for this package to work both client and server in jspm and supporting the conditional package map feature being released in jspm 0.17.

I completely understand if you'd rather not support this here, but it will simplify user configuration locally having it in one place. There is no maintenance burden either as I would continue to maintain this personally.

Just let me know if you have any questions at all, and thanks for considering.
