### PR TITLE
Add react-native compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/devongovett/browserify-zlib.git"
+  },
+  "react-native": {
+    "_stream_transform": "readable-stream/transform"
   }
 }


### PR DESCRIPTION
The React Native packager doesn't have a way of automatically replacing requires of core node libraries with browser compatible alternatives. However facebook/react-native#2208 allows the packager to override modules returned by require, but the override must be specified by the packages directly dependent on the node core module, hence this PR.