### PR TITLE
package.json: use `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "test": "node_modules/tape/bin/tape test/*.js"
   },
   "main": "src/index.js",
+  "files": [
+    "src"
+  ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
See substack/node-browserify#1486. This will reduce install size by not including tests.