### PR TITLE
Gunzip shouldn't fail on Z_BUF_ERROR

### DIFF
--- a/src/binding.js
+++ b/src/binding.js
@@ -183,7 +183,10 @@ Zlib.prototype._write = function(flush, input, in_off, in_len, out, out_off, out
       throw new Error("Unknown mode " + this.mode);
   }
   
-  if (status !== exports.Z_STREAM_END && status !== exports.Z_OK) {
+  if (status !== exports.Z_STREAM_END
+      && status !== exports.Z_OK
+      // Issue #14: Bug: Buffer error is not fatal
+      && status !== exports.Z_BUF_ERROR) {
     this._error(status);
   }
   


### PR DESCRIPTION
It just means the input or output is blocking and you should try again
soon.
