### PR TITLE
Remove invalid "main" value

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.4",
   "description": "Full zlib module for browserify",
   "keywords": ["zlib", "browserify"],
-  "main": "index.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
"main" is specified twice. The first occurrence refers to a file that doesn't exist so remove it.