### PR TITLE
remove phantomjs from karma tests and dev deps

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,6 @@ module.exports = function (karma) {
     mochaOwnReporter: {
       reporter: 'spec'
     },
-    browsers: process.env.TRAVIS ? ['Firefox', 'PhantomJS'] : ['Chrome', 'PhantomJS']
+    browsers: process.env.TRAVIS ? ['Firefox'] : ['Firefox', 'Chrome']
   })
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-mocha-own-reporter": "^1.1.2",
-    "karma-phantomjs-launcher": "^1.0.4",
     "mocha": "^3.4.2",
-    "phantomjs-prebuilt": "^2.1.14",
     "standard": "^10.0.2",
     "watchify": "^3.9.0"
   },


### PR DESCRIPTION
PhantomJS is not really maintained anymore, and its karma tests are now failing in travis and on my machine.

This pull requests remove phantom from the dev deps and the karma config.

Fixes #28 and #31 