### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/test/test-zlib-truncated.js
+++ b/test/test-zlib-truncated.js
@@ -53,7 +53,7 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli'
     assert.doesNotThrow(function() {
       const result = zlib[methods.decompSync](truncated, syncFlushOpt)
         .toString();
-      assert.equal(result, inputString.substr(0, result.length));
+      assert.equal(result, inputString.slice(0, result.length));
     });
 
     // async truncated input test, finishFlush = Z_SYNC_FLUSH
@@ -61,7 +61,7 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli'
       assert.ifError(err);
 
       const result = decompressed.toString();
-      assert.equal(result, inputString.substr(0, result.length));
+      assert.equal(result, inputString.slice(0, result.length));
     });
   });
 });


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.